### PR TITLE
removed dockerfile default config path

### DIFF
--- a/onlyswaps-verifier/Dockerfile
+++ b/onlyswaps-verifier/Dockerfile
@@ -44,4 +44,4 @@ FROM debian:bookworm-slim AS runtime
 RUN apt-get update && apt-get install -y libssl3 dnsutils
 WORKDIR /app
 COPY --from=builder /app/target/release/onlyswaps-verifier /usr/local/bin
-ENTRYPOINT ["/usr/local/bin/onlyswaps-verifier", "--config", "/data/config.json"]
+ENTRYPOINT ["/usr/local/bin/onlyswaps-verifier"]

--- a/onlyswaps-verifier/src/config.rs
+++ b/onlyswaps-verifier/src/config.rs
@@ -57,10 +57,7 @@ impl TryFrom<ConfigFile> for AppConfig {
 }
 
 pub(crate) fn load_app_config(cli: &CliConfig) -> anyhow::Result<AppConfig> {
-    tracing::info!(
-        config_path = cli.config_path.as_str(),
-        "loading config file"
-    );
+    println!("Loading app config from {}", &cli.config_path);
 
     let path = Path::new(&cli.config_path);
     let config_file = match path.extension().and_then(|s| s.to_str()) {


### PR DESCRIPTION
- println instead of tracing to print config path because we can't load the tracing subscriber yet