### PR TITLE
fix: signing now happens in parallel

### DIFF
--- a/onlyswaps-verifier/src/eth.rs
+++ b/onlyswaps-verifier/src/eth.rs
@@ -208,8 +208,14 @@ impl<P: Provider> Network<P> {
             )
             .send()
             .await?;
-        let tx_hash = tx.watch().await?;
+
+        let tx_hash = tx
+            .with_required_confirmations(1)
+            .with_timeout(Some(self.request_timeout))
+            .watch()
+            .await?;
         tracing::info!(tx_hash = tx_hash.to_string(), "verified swap");
+
         Ok(())
     }
 }


### PR DESCRIPTION
The ordering of events is not guaranteed between RPC/new events. Previously signin was serialised, so different nodes could get stuck signing different messages and never making any progress.

This PR parallelises the signing of messages (while still separated from consumption by a channel)