### PR TITLE
feat(adkg-cli): rework protocol execution

### DIFF
--- a/crates/adkg-cli/src/config.rs
+++ b/crates/adkg-cli/src/config.rs
@@ -27,12 +27,24 @@ pub struct AdkgSecret {
     pub sk: String,
 }
 
+/// The ADKG public output on a source group (i.e., the one used by the ADKG), and on a destination
+/// group (i.e., the one used for signatures, etc.)
 #[derive(Clone, Serialize, Deserialize)]
 pub struct AdkgPublic {
     pub adkg_scheme_name: String,
     pub genesis_timestamp: i64,
+
+    /// The destination group public key used for signatures
     pub group_pk: String,
+    /// The destination node public keys used for signatures
     pub node_pks: Vec<AdkgNodePk>,
+
+    /// The group public key obtained in the ADKG source group.
+    #[serde(default)]
+    pub group_pk_source: String,
+    /// The node public keys obtained in the ADKG source group.
+    #[serde(default)]
+    pub node_pks_source: Vec<AdkgNodePk>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/adkg/src/aba/multi_aba.rs
+++ b/crates/adkg/src/aba/multi_aba.rs
@@ -145,10 +145,16 @@ where
         // Cancel each of the tasks
         self.cancels.iter().for_each(|c| c.cancel());
 
-        let outputs = join_all(
+        let outputs: Vec<_> = join_all(
             PartyId::iter_all(self.n_instances)
                 .zip(self.tasks.into_iter())
-                .filter_map(|(id, task)| task.map(|t| t.map(move |out| (id, out)))),
+                .filter_map(|(id, task)| {
+                    let task = task?;
+                    Some(async move {
+                        let out = task.await;
+                        (id, out)
+                    })
+                }),
         )
         .await;
 


### PR DESCRIPTION
Reworks the execution of the ADKG in the cli to fix #96 & fix #97 .

The new execution flow is as follows:
 1. Execute ADKG on G1
  1a. The ADKG has sent an output through the oneshot channel, continue to 2.
  1b. The ADKG has timed out, or returned an error => exit now
 2. Write the priv/pub output to the specified files
 3. Execute the G1 to G2 swap protocol
  3.a. The swap protocol completes, write the priv/pub output to the specified files, continue to 4.
  3.b. The ADKG task has completed its grace period, continue to 4. <-- The swap protocol has timed out.
 4. Wait for the ADKG task to complete its grace period <-- This gives time for both the ADKG & the swap protocol to complete on every node
 5. Write the transcripts to disk

The main fix consists of writing into the priv/pub files as soon as we get the ADKG output. 
We also now store both the output on the source group, and the output on the swapped group, resulting in a file with the following format:
```toml
adkg_scheme_name = "DXKR23-Bn254G1-Keccak256"
genesis_timestamp = 1756913660
group_pk = "2mHtp5Tfo3LkEO9s1DN4RkhkmpT4cTvs3Uv+ld8UTc8oqB5dZOaAdpGQqimMdJ+yuVbp4sIFMkhjva3NnxSL1Q=="
group_pk_source = "2Nj0GQDtqAQ5liambQul3QgnrmTxFU5UrDlOgRnziaY="

[[node_pks]]
id = 1
pk = "j5nfW8teKjZABd6pO+isTvdlk1IorZ0VGnha+xGTWiMV5DQP6CkCeVoNqSAzGp3lJZuB7wr5Ev9CH/5h0POzbg=="
peer_id = "12D3KooWN21eTopREUZfyfmY8aKjreUjtCeQkWd6hbMENBCQ8njc"
multiaddr = "/ip4/127.0.0.1/tcp/15001"

[[node_pks]]
...

[[node_pks_source]]
id = 1
pk = "qRuY9ZISP9/n5gugqazhYkKV0asV+LrFAhkzeVKgWEU="
peer_id = "12D3KooWN21eTopREUZfyfmY8aKjreUjtCeQkWd6hbMENBCQ8njc"
multiaddr = "/ip4/127.0.0.1/tcp/15001"

[[node_pks_source]]
...
```

The attributes suffixed with `_source` shouldn't be used for applications, but they can be helpful for recovery should the swap protocol ever fail, while the ADKG succeeds.