### PR TITLE
fix: allow missing config for timeout

### DIFF
--- a/bin/onlyswaps-verifier/src/config.rs
+++ b/bin/onlyswaps-verifier/src/config.rs
@@ -20,8 +20,9 @@ use std::time::Duration;
 pub struct AppConfigFile {
     #[serde(default)]
     pub agent: AgentConfig,
-    pub networks: Vec<NetworkConfig>,
+    #[serde(default)]
     pub timeout: TimeoutConfig,
+    pub networks: Vec<NetworkConfig>,
     pub longterm_secret_path: FileArg<PrivateKeyMaterial>,
     pub adkg_public_path: FileArg<AdkgPublic>,
     pub adkg_secret_path: FileArg<AdkgSecret>,


### PR DESCRIPTION
- added annotation to the wrong struct fuuuu