### PR TITLE
Revision of how we handle Docker tags

### DIFF
--- a/.github/workflows/check-rust-bindings.yml
+++ b/.github/workflows/check-rust-bindings.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ["randamu-self-hosted-default"]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 

--- a/.github/workflows/push-adkg-cli-docker.yml
+++ b/.github/workflows/push-adkg-cli-docker.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: "randamu-self-hosted-default"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 

--- a/.github/workflows/push-blocklock-agent-docker.yml
+++ b/.github/workflows/push-blocklock-agent-docker.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: "randamu-self-hosted-default"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 

--- a/.github/workflows/push-dsigner-docker.yml
+++ b/.github/workflows/push-dsigner-docker.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: "randamu-self-hosted-default"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 

--- a/.github/workflows/push-monitoring.yml
+++ b/.github/workflows/push-monitoring.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ["randamu-self-hosted-default"]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: "recursive"
 

--- a/.github/workflows/push-onlyswaps-solver.yml
+++ b/.github/workflows/push-onlyswaps-solver.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: "randamu-self-hosted-default"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: "recursive"
 

--- a/.github/workflows/push-onlyswaps-state-api.yml
+++ b/.github/workflows/push-onlyswaps-state-api.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: "randamu-self-hosted-default"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: "recursive"
 

--- a/.github/workflows/push-onlyswaps-verifier.yml
+++ b/.github/workflows/push-onlyswaps-verifier.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: "randamu-self-hosted-default"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: "recursive"
 

--- a/.github/workflows/push-randomness-agent-docker.yml
+++ b/.github/workflows/push-randomness-agent-docker.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: "randamu-self-hosted-default"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 

--- a/.github/workflows/rust-build-and-tests.yml
+++ b/.github/workflows/rust-build-and-tests.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ["randamu-self-hosted-default"]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 


### PR DESCRIPTION
We are currently tagging all images using their SHA hash, but that means our caching is not working because we upload the SHA version of the cache but next time we pull it, the SHA has changed because it got some new commits. 
Meaning we're uploading a ton of useless tagged images than never get cleanup in our registries.

It used to be the case that `steps.meta.outputs.version` was the value of the SHA tag, now it should be the branch name instead.

This changes all of that:
- Properly tagging images with branch name instead of commit hash to use caching properly.
- Getting rid of Short SHA tricks.
- Relying on the Docker meta step to produce a main-latest tag.
- Optimized to allow for effective cleanup of our registry.