### PR TITLE
fix: docker lint from github

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,11 @@ ARG BINARY_PATH
 ARG BINARY_NAME
 
 FROM debian:bookworm-slim AS runtime
-RUN apt-get update && apt-get install -y libssl3 dnsutils && rm -rf /var/lib/apt/lists/*
+
+ARG BINARY_PATH
+ARG BINARY_NAME
+
+RUN apt-get update && apt-get install -y --no-install-recommends libssl3 dnsutils && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY ${BINARY_PATH} /usr/local/bin/${BINARY_NAME}
 


### PR DESCRIPTION
I saw it complain about undefined vars in the dockerfile and it seems we need to redefine the args at each stage