### PR TITLE
chore: clippy fixes

### DIFF
--- a/bin/adkg-cli/src/adkg_dxkr23.rs
+++ b/bin/adkg-cli/src/adkg_dxkr23.rs
@@ -697,21 +697,6 @@ where
     Ok(())
 }
 
-#[serde_with::serde_as]
-#[derive(Serialize, Deserialize)]
-struct ChaCha20BroadcastCiphertext {
-    /// one unique ciphertext per participant to store a shared encryption key
-    encrypted_key: MultiHybridCiphertext,
-
-    /// chacha20+poly1305 nonce
-    #[serde_as(as = "utils::Base64OrBytes")]
-    nonce: Vec<u8>,
-
-    /// a (large) message encrypted with the shared encryption key
-    #[serde_as(as = "utils::Base64OrBytes")]
-    ciphertext: Vec<u8>,
-}
-
 /// An encrypted adkg transcript that can be stored and sent to nodes.
 /// Authenticity of the transcript is obtained by relying on hybrid encryption w/ static public keys.
 #[serde_with::serde_as]

--- a/crates/signer/src/bls.rs
+++ b/crates/signer/src/bls.rs
@@ -104,19 +104,6 @@ impl From<BlsSignatureRequest> for SignatureRequest {
     serialize = "Group<BLS>: Serialize",
     deserialize = "Group<BLS>: Deserialize<'de>"
 ))]
-struct PartialSignatureWithMessage<BLS>
-where
-    BLS: BlsVerifier,
-{
-    m: Vec<u8>,
-    sig: Group<BLS>,
-}
-
-#[derive(Clone, Serialize, Deserialize)]
-#[serde(bound(
-    serialize = "Group<BLS>: Serialize",
-    deserialize = "Group<BLS>: Deserialize<'de>"
-))]
 struct PartialSignatureWithRequest<BLS>
 where
     BLS: BlsVerifier,

--- a/crates/signer/src/bls/dsigner_scheme_impl.rs
+++ b/crates/signer/src/bls/dsigner_scheme_impl.rs
@@ -11,7 +11,6 @@ use bytes::Bytes;
 use futures_util::FutureExt;
 use futures_util::future::BoxFuture;
 use itertools::Either;
-use serde::{Deserialize, Serialize};
 use utils::serialize::point::{
     PointDeserializeCompressed, PointSerializeCompressed, PointSerializeUncompressed,
 };
@@ -37,12 +36,6 @@ impl<BLS: BlsVerifier> AsyncThresholdSigner<BLS> {
             filter,
         }
     }
-}
-
-#[derive(Clone, Serialize, Deserialize)]
-struct PartialSignature<G> {
-    id: u16,
-    sig: G,
 }
 
 #[derive(thiserror::Error, Debug)]


### PR DESCRIPTION
I seemingly forgot about some structs, and clippy was happy with it before upgrading runners to rust 1.91