### PR TITLE
Make artifact paths relative during metadata generation

### DIFF
--- a/.github/workflows/build-all-binaries.yml
+++ b/.github/workflows/build-all-binaries.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           # Build with JSON output to capture build artifacts
           if [ "${{ env.ENABLE_TIMING_REPORTS }}" = "true" ]; then
-            cargo build --release -p monitoring -p dcipher-network --timings --message-format=json > build-output.json
+            cargo build --release --workspace --bins --examples --all-features --timings --message-format=json > build-output.json
           else
             cargo build --release --workspace --bins --examples --all-features --message-format=json > build-output.json
           fi

--- a/.github/workflows/build-and-push-docker-images.yml
+++ b/.github/workflows/build-and-push-docker-images.yml
@@ -12,7 +12,7 @@ on:
         description: 'Enable test mode (uses candyland-test registry and draft releases)'
         required: false
         type: boolean
-        default: true
+        default: false
       docker_push:
         description: 'Enable docker push'
         required: false
@@ -117,18 +117,6 @@ jobs:
         with:
           name: binaries-${{ github.sha }}
           path: target/release
-
-      - name: Debug - List directory structure and matrix variables
-        run: |
-          echo "=== Directory structure after downloads ==="
-          ls -la
-          echo ""
-          echo "=== Target directory structure ==="
-          ls -laR target/
-          echo ""
-          echo "=== Matrix variables ==="
-          echo "matrix.app.binary_path: ${{ matrix.app.binary_path }}"
-          echo "matrix.app.binary_name: ${{ matrix.app.binary_name }}"
 
       - name: Docker meta
         id: meta


### PR DESCRIPTION
Rather than substitute out an absolute path, use the working directory to the metadata.

We could probably leverage the github injected env var if we care about absolute paths but I think this is the better choice.