### PR TITLE
fix(dsigner-legacy-http): update config due to ser / deser rt inconsistency

### DIFF
--- a/bin/dsigner/examples/dsigner_legacy_http/arguments_parser.rs
+++ b/bin/dsigner/examples/dsigner_legacy_http/arguments_parser.rs
@@ -2,7 +2,7 @@ use anyhow::anyhow;
 use clap::Parser;
 use config::keys::{Bn254SecretKey, Libp2pKeyWrapper, serde_to_string_from_str};
 use figment::Figment;
-use figment::providers::{Format, Serialized, Toml};
+use figment::providers::{Format, Toml};
 use serde::{Deserialize, Serialize};
 use std::num::{NonZeroU16, NonZeroUsize};
 use std::path::PathBuf;
@@ -117,11 +117,7 @@ pub struct DSignerConfig {
 
 impl DSignerConfig {
     pub fn parse() -> anyhow::Result<Self> {
-        let c: Args = Figment::new()
-            .merge(Serialized::defaults(Args::parse()))
-            .merge(Toml::file("config.toml"))
-            .extract()?;
-
+        let c: Args = Args::parse();
         if c.key_config.t > c.key_config.n {
             Err(anyhow!("t cannot be greater than n"))?
         }


### PR DESCRIPTION
The dsigner pod fails to start due to an inconsistency between serialization (hex) & deserialization (base64 only since b2f7371f519ee4b8d7920c5fb62c3df62d4f1c21) during a round-trip.

This PR removes the round-trip used in the `dsigner_legacy_http` by removing the `config.toml` support. No impact since `config.toml` is not used.