### PR TITLE
fix(state-api): update filter that always returned false for non-verified reqs

### DIFF
--- a/bin/onlyswaps-state-api/src/filter.rs
+++ b/bin/onlyswaps-state-api/src/filter.rs
@@ -51,6 +51,11 @@ fn is_requested_time(tx: &SwapTransaction, start: Option<u64>, end: Option<u64>)
 }
 
 fn is_verified_time(tx: &SwapTransaction, start: Option<u64>, end: Option<u64>) -> bool {
+    // if neither start nor end are specified, return true
+    if start.is_none() && end.is_none() {
+        return true;
+    }
+
     let start = start.unwrap_or(0);
     let end = end.unwrap_or(u64::MAX);
     match &tx.verified_time {


### PR DESCRIPTION
The verification time filter was always returning `false` for requests that were not yet verified, this fixes the issue by returning true if neither the verification start nor end time are specified.