### PR TITLE
fix(adkg): concurrency issue when waiting for RBCs

### DIFF
--- a/crates/adkg/Cargo.toml
+++ b/crates/adkg/Cargo.toml
@@ -34,7 +34,6 @@ sha2 = { workspace = true, optional = true}
 sha3.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
-tracing-subscriber.workspace = true
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "sync"] }
 tokio-util.workspace = true
 futures.workspace = true
@@ -45,4 +44,5 @@ dcipher-network = { workspace = true, features = ["in_memory"] }
 ark-bn254.workspace = true
 ark-bls12-381.workspace = true
 utils = { workspace = true, features = ["bls12-381", "bn254", "sha3"] }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 rayon = "1.0"

--- a/crates/adkg/src/aba.rs
+++ b/crates/adkg/src/aba.rs
@@ -57,7 +57,7 @@ pub trait Aba: Send {
 }
 
 /// A binary estimate can either be 0/1, or \bot.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[repr(u8)]
 pub enum Estimate {
     Bot,

--- a/crates/adkg/src/aba/crain20/broadcast.rs
+++ b/crates/adkg/src/aba/crain20/broadcast.rs
@@ -1,0 +1,146 @@
+//! Implementations of BV_broadcast and SBV_broadcast.
+
+use crate::aba::crain20::messages::{
+    AbaMessage, AuxStage, AuxiliaryMessage, EstimateMessage, View,
+};
+use crate::aba::crain20::{AbaCrain20Instance, AbaState};
+use crate::aba::{Estimate, crain20};
+use crate::helpers::PartyId;
+use crate::network::broadcast_with_self;
+use ark_ec::CurveGroup;
+use dcipher_network::TransportSender;
+use std::sync::Arc;
+use tracing::{Level, error, event};
+
+impl<CG, CK, H, TS> AbaCrain20Instance<CG, CK, H, TS>
+where
+    CG: CurveGroup,
+    TS: TransportSender<Identity = PartyId> + Clone,
+{
+    /// Binary-value broadcast described in https://dl.acm.org/doi/10.1145/2785953, Figure 1
+    /// Send the current party's estimate to all other nodes with an Estimate message.
+    #[tracing::instrument(skip(self))]
+    async fn bv_broadcast(&self, r: u8, stage: AuxStage, v: Estimate) {
+        // 1: broadcast B_VAL(v) to all
+        let msg_est = AbaMessage::Estimate(EstimateMessage {
+            round: r,
+            stage,
+            estimate: v,
+        });
+
+        event!(
+            Level::DEBUG,
+            "Node `{}` at round `{r}` sending {:?} to all",
+            self.config.id,
+            msg_est
+        );
+        if let Err(e) =
+            broadcast_with_self(&msg_est, &self.config.retry_strategy, &self.sender).await
+        {
+            error!(
+                "Node `{}` failed to broadcast estimate message: {e:?}",
+                self.config.id
+            )
+        }
+    }
+
+    /// Synchronized binary-value broadcast described in https://dl.acm.org/doi/10.1145/2785953, Figure 2
+    /// Send the current party's estimate to all other nodes with an Estimate message.
+    #[tracing::instrument(skip(self, state))]
+    pub(super) async fn sbv_broadcast(
+        &self,
+        r: u8,
+        stage: AuxStage,
+        v: Estimate,
+        state: &Arc<AbaState<CG, H>>,
+    ) -> View {
+        // 1: BV_Broadcast(v)
+        self.bv_broadcast(r, stage, v).await;
+
+        event!(
+            Level::DEBUG,
+            "Node `{}` waiting for bin values",
+            self.config.id
+        );
+        let bin_values = loop {
+            // 2: wait until bin_values \neq \emptyset
+            state.notify_bin_values.notified((r, stage)).await;
+
+            let bin_values = state.bin_values.lock().await;
+            let bin_values = &bin_values.get(&r).cloned().unwrap_or_default()[stage];
+            if !bin_values.is_empty() {
+                event!(
+                    Level::DEBUG,
+                    "Node `{}` obtained bin_values = `{bin_values:?}`",
+                    self.config.id
+                );
+                break bin_values.clone();
+            }
+        };
+
+        // 3: Send AUX(w) for w \in bin_values to all
+        for w in bin_values.iter() {
+            let msg_aux = AbaMessage::Auxiliary(AuxiliaryMessage {
+                round: r,
+                stage,
+                estimate: *w,
+            });
+            event!(
+                Level::DEBUG,
+                "Node `{}` sending {:?} to all",
+                self.config.id,
+                msg_aux
+            );
+
+            if let Err(e) =
+                broadcast_with_self(&msg_aux, &self.config.retry_strategy, &self.sender).await
+            {
+                error!(
+                    "Node `{}` failed to broadcast aux message: {e:?}",
+                    self.config.id
+                )
+            }
+        }
+
+        // 4: wait until \exists a set view s.t.
+        //  (1) view \subseteq bin_values, and
+        //  (2) contained in AUX(.) messages received from n - t nodes
+        let view = loop {
+            event!(
+                Level::DEBUG,
+                "Node `{}` waiting for count_aux notification",
+                self.config.id
+            );
+
+            // wake up each time after having received n - t aux, or on bin_values update
+            crain20::future_select_pin(
+                state.notify_count_aux.notified((r, stage)),
+                state.notify_bin_values.notified((r, stage)),
+            )
+            .await;
+
+            let aux_views = state.aux_views.lock().await;
+            let bin_values = state.bin_values.lock().await; // warn: two locks, could deadlock
+            let aux_views = aux_views.get(&(r, stage)).to_owned().unwrap_or_default();
+            let bin_values = &bin_values.get(&r).cloned().unwrap_or_default()[stage];
+            let view = self.construct_view(bin_values, &aux_views);
+            if let Some(view) = view {
+                event!(
+                    Level::DEBUG,
+                    "Node {} obtained view = `{view:?}`",
+                    self.config.id
+                );
+                break view;
+            } else {
+                event!(
+                    Level::DEBUG,
+                    "Node {} received notify_count_aux notification while having no binary estimates / not enough aux",
+                    self.config.id
+                );
+            }
+        };
+        // 5: return view
+        #[allow(clippy::let_and_return)] // for clarity
+        view
+    }
+}

--- a/crates/adkg/src/aba/crain20/coin.rs
+++ b/crates/adkg/src/aba/crain20/coin.rs
@@ -1,0 +1,207 @@
+//! Functions used for the coin toss protocol
+
+use crate::aba::crain20::ecdh_coin_toss::{Coin, EcdhCoinTossEval};
+use crate::aba::crain20::messages::{AbaMessage, CoinEvalMessage};
+use crate::aba::crain20::{AbaCrain20Instance, AbaError, AbaState, CoinKeys};
+use crate::helpers::PartyId;
+use crate::network::broadcast_with_self;
+use ark_ec::CurveGroup;
+use dcipher_network::TransportSender;
+use digest::core_api::BlockSizeUser;
+use digest::crypto_common::rand_core::CryptoRng;
+use digest::{DynDigest, FixedOutputReset};
+use rand::RngCore;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tokio::sync::oneshot;
+use tracing::{Level, error, event};
+use utils::hash_to_curve::HashToCurve;
+use utils::serialize::fq::FqSerialize;
+use utils::serialize::point::PointSerializeCompressed;
+
+impl<CG, CK, H, TS> AbaCrain20Instance<CG, CK, H, TS>
+where
+    CG: CurveGroup + Copy + HashToCurve + PointSerializeCompressed,
+    CG::ScalarField: FqSerialize,
+    EcdhCoinTossEval<CG, H>: for<'de> Deserialize<'de>,
+    CK: Send + Into<CoinKeys<CG>> + 'static,
+    H: Default + DynDigest + FixedOutputReset + BlockSizeUser + Clone + Send + Sync + 'static,
+    TS: TransportSender<Identity = PartyId>,
+{
+    /// Try to get the output from the coin keys receiver, return an error otherwise.
+    pub(super) async fn get_coin_keys(
+        &self,
+        r: u8,
+        coin_keys_receiver: oneshot::Receiver<CK>,
+    ) -> Result<CK, AbaError> {
+        event!(
+            Level::DEBUG,
+            "Node `{}` at round `{r}` has not yet obtained keys for common coin protocol, waiting.",
+            self.config.id
+        );
+
+        // Return coin_keys if sender not dropped, err otherwise
+        match coin_keys_receiver.await {
+            Ok(coin_keys) => {
+                event!(
+                    Level::DEBUG,
+                    "Node `{}` at round `{r}` obtained keys for common coin protocol",
+                    self.config.id
+                );
+
+                Ok(coin_keys)
+            }
+            Err(_) => {
+                error!(
+                    "Node `{}` at round `{r}` failed to obtain common coin input through channel: sender dropper. Aborting ABA.",
+                    self.config.id
+                );
+                Err(AbaError::CoinKeysRecv)
+            }
+        }
+    }
+
+    /// Try to generate and send a partial coin evaluation, or return an error otherwise.
+    pub(super) async fn send_coin_eval<RNG>(
+        &self,
+        r: u8,
+        coin_keys: &CoinKeys<CG>,
+        rng: &mut RNG,
+    ) -> Result<(), Box<AbaError>>
+    where
+        RNG: RngCore + CryptoRng,
+    {
+        let eval = EcdhCoinTossEval::<CG, H>::eval(
+            &coin_keys.sk,
+            &Self::coin_input(usize::from(self.sid), &coin_keys.combined_vk, r)?,
+            &self.config.g,
+            rng,
+        )
+        .map_err(|e| AbaError::CoinToss(e, "failed to generate coin toss evaluation: {e}"))?;
+
+        let msg_coin_eval = AbaMessage::CoinEval(CoinEvalMessage::new(eval, r).unwrap());
+
+        if let Err(e) =
+            broadcast_with_self(&msg_coin_eval, &self.config.retry_strategy, &self.sender).await
+        {
+            error!(
+                "Node `{}` failed to broadcast coin eval message: {e:?}",
+                self.config.id
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Wait for enough evaluations and try to recover a common coin. Returns an error if too many evaluations are invalid.
+    pub(super) async fn get_coin(
+        &self,
+        r: u8,
+        state: &Arc<AbaState<CG, H>>,
+        coin_keys: &CoinKeys<CG>,
+    ) -> Result<Coin, Box<AbaError>> {
+        // Get the input of the common coin protocol
+        let coin_input = Self::coin_input(
+            usize::from(self.sid),
+            &coin_keys.combined_vk.into_affine().into(),
+            r,
+        )?;
+
+        loop {
+            // Wait until we have enough valid partial coins evals for the current round
+            event!(
+                Level::DEBUG,
+                "Node `{}` at round `{r}` waiting for coin evaluations",
+                self.config.id
+            );
+            state.notify_enough_coin_evals.notified(r).await;
+
+            // mutex locked for the entire duration, either that or cloning evals
+            let coin_evals = state.coin_evals.lock().await;
+            let Some((senders, evals)) = coin_evals.get_all(&r) else {
+                event!(
+                    Level::DEBUG,
+                    "Node `{}` at round `{r}` received coin evals notifications while not having evals",
+                    self.config.id
+                );
+                continue;
+            };
+
+            if evals.len() < self.config.t + 1 {
+                event!(
+                    Level::DEBUG,
+                    "Node `{}` at round `{r}` does not have enough evals: {} < {}",
+                    self.config.id,
+                    evals.len(),
+                    self.config.t
+                );
+                continue; // not enough evals for this round yet
+            };
+
+            // Try to get and return the common coin
+            let coin_vks: Vec<_> = senders.iter().map(|&j| coin_keys.vks[j]).collect();
+            match EcdhCoinTossEval::get_coin(
+                &evals,
+                &senders,
+                &coin_vks,
+                &coin_input,
+                &self.config.g,
+                self.config.t + 1,
+            ) {
+                Ok(coin) => return Ok(coin),
+                Err(e) => {
+                    // Failed to obtain the common coin, we either continue if we don't have all evals yet, or we abort
+                    event!(
+                        Level::WARN,
+                        "Node `{}` at round `{r}` failed to obtain a common coin due to invalid eval(s): {e:?}",
+                        self.config.id
+                    );
+
+                    if evals.len() < self.config.n {
+                        continue;
+                    } else {
+                        event!(
+                            Level::ERROR,
+                            "Node `{}` at round `{r}` failed to obtain a common coin with n evals: {e:?}. Aborting ABA with error.",
+                            self.config.id
+                        );
+                        Err(AbaError::CoinToss(
+                            e,
+                            "failed to obtain common coin with all evals",
+                        ))?
+                    }
+                }
+            }
+        }
+    }
+
+    /// Get the input to the common coin.
+    fn coin_input(sid: usize, combined_vk: &CG, round: u8) -> Result<Vec<u8>, Box<AbaError>> {
+        CoinInput {
+            combined_vk: *combined_vk,
+            sid,
+            round,
+        }
+        .serialize()
+    }
+}
+
+/// Structure used to serialize the input of the coin
+#[derive(Serialize)]
+#[serde(bound(serialize = "CG: PointSerializeCompressed",))]
+struct CoinInput<CG> {
+    #[serde(with = "utils::serialize::point::base64")]
+    combined_vk: CG,
+    sid: usize,
+    round: u8,
+}
+
+impl<CG> CoinInput<CG>
+where
+    CG: PointSerializeCompressed,
+{
+    fn serialize(&self) -> Result<Vec<u8>, Box<AbaError>> {
+        bson::to_vec(&self)
+            .map_err(|e| AbaError::BsonSer(e, "failed to serialize CoinInput to bson").into())
+    }
+}

--- a/crates/adkg/src/aba/crain20/recv_handler.rs
+++ b/crates/adkg/src/aba/crain20/recv_handler.rs
@@ -1,0 +1,177 @@
+//! Handles message received by other nodes.
+
+use crate::aba::crain20::ecdh_coin_toss::EcdhCoinTossEval;
+use crate::aba::crain20::messages::{AbaMessage, EstimateMessage};
+use crate::aba::crain20::{AbaCrain20, AbaCrain20Config, AbaState, PerPartyStorage};
+use crate::helpers::{PartyId, SessionId};
+use crate::network::broadcast_with_self;
+use ark_ec::CurveGroup;
+use dcipher_network::{ReceivedMessage, Transport};
+use futures::StreamExt;
+use serde::Deserialize;
+use std::borrow::Borrow;
+use std::collections::HashSet;
+use std::sync::Arc;
+use tokio_util::sync::CancellationToken;
+use tracing::{Instrument, debug, error, info, trace, warn};
+
+impl<CG, CK, H, T> AbaCrain20<CG, CK, H, T>
+where
+    CG: CurveGroup,
+    EcdhCoinTossEval<CG, H>: for<'de> Deserialize<'de>,
+    T: Transport<Identity = PartyId>,
+{
+    /// Thread responsible for receiving all types of ABA messages and transmitting notifications.
+    pub(super) async fn recv_thread(
+        sid: SessionId,
+        config: Arc<AbaCrain20Config<CG, CK, H>>,
+        receiver: T::ReceiveMessageStream,
+        sender: T::Sender,
+        cancel: CancellationToken,
+        state: Arc<AbaState<CG, H>>,
+    ) {
+        let id = config.id;
+        // Stop the thread upon receiving a signal from the cancellation token
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                info!("Node `{id}` in ABA with sid `{sid}` stopping recv_thread");
+            }
+
+            _ = Self::recv_loop(config, receiver, sender, state).instrument(tracing::info_span!("recv_loop", ?sid)) => {}
+        }
+    }
+
+    /// Infinite loop listening for ABA messages and sending notifications.
+    async fn recv_loop(
+        config: Arc<AbaCrain20Config<CG, CK, H>>,
+        mut receiver: T::ReceiveMessageStream,
+        sender: T::Sender,
+        state: Arc<AbaState<CG, H>>,
+    ) {
+        // Local variables
+        let mut count_est = PerPartyStorage::new();
+        let mut sent_estimate: HashSet<EstimateMessage> = HashSet::new();
+
+        loop {
+            let ReceivedMessage {
+                sender: sender_id,
+                content,
+                ..
+            } = match receiver.next().await {
+                Some(Ok(m)) => m,
+                Some(Err(e)) => {
+                    warn!("Node `{}` failed to recv: {e:?}", config.id);
+                    continue;
+                }
+                None => {
+                    error!(
+                        "Node `{}` failed to recv: no more items in stream",
+                        config.id
+                    );
+                    return;
+                }
+            };
+
+            let m: AbaMessage = match bson::from_slice(&content) {
+                Ok(m) => m,
+                Err(e) => {
+                    error!(error = ?e, "Node `{}` failed to deserialize message", config.id);
+                    continue;
+                }
+            };
+            trace!(
+                "Node `{}` received message {m:?} from {sender_id}",
+                config.id,
+            );
+
+            match m {
+                // 4: upon receiving BVAL(v) do
+                AbaMessage::Estimate(est) => {
+                    count_est.insert_once(est, sender_id, true);
+                    let count = count_est.get_count(&est);
+
+                    #[allow(clippy::int_plus_one)]
+                    if count >= 2 * config.t + 1 {
+                        // 7: if BVAL(V) received from 2t + 1 different nodes then
+                        // 8: bin_values := bin_values \cup {v}
+                        // add the estimate to the binary values
+                        let mut r_bin_values = state.bin_values.lock().await;
+                        let bin_values = &mut r_bin_values.entry(est.round).or_default()[est.stage];
+                        if bin_values.contains(&est.estimate) {
+                            drop(r_bin_values);
+                        } else {
+                            bin_values.push(est.estimate);
+                            drop(r_bin_values);
+
+                            // notify of update to bin_values
+                            debug!(
+                                "Node {} notifying bin values for round {}",
+                                config.id, est.round
+                            );
+                            state.notify_bin_values.notify_one((est.round, est.stage));
+                        };
+                    } else if count >= config.t + 1 && !sent_estimate.contains(&est) {
+                        // 5: if BVAL(v) received from t + 1 different nodes AND BVAL(v) was not sent, then
+                        // 6: Send BVAL(v) to all nodes
+                        let msg_est = AbaMessage::Estimate(est);
+                        if let Err(e) =
+                            broadcast_with_self(&msg_est, &config.retry_strategy, &sender).await
+                        {
+                            error!(
+                                "Node `{}` failed to broadcast estimate message: {e:?}",
+                                config.id
+                            )
+                        }
+                        sent_estimate.insert(est);
+                    }
+                }
+
+                AbaMessage::Auxiliary(aux) => {
+                    let mut aux_views = state.aux_views.lock().await;
+                    // Add the new estimate to the current view
+                    aux_views
+                        .entry((aux.round, aux.stage), sender_id)
+                        .or_default()
+                        .insert(aux.estimate);
+
+                    // notify once we got at least n - t aux messages
+                    if aux_views.get_count(&(aux.round, aux.stage)) >= config.n - config.t {
+                        state.notify_count_aux.notify_one((aux.round, aux.stage));
+                    }
+                }
+
+                AbaMessage::AuxiliarySet(aux_set) => {
+                    // Insert auxset view, at most once per sender_id
+                    let mut auxset_views = state.auxset_views.lock().await;
+                    auxset_views.insert_once(aux_set.round, sender_id, aux_set.view);
+
+                    // notify once we got at least n - t auxset messages
+                    if auxset_views.get_count(&aux_set.round) >= config.n - config.t {
+                        state.notify_count_auxset.notify_one(aux_set.round);
+                    }
+                }
+
+                AbaMessage::CoinEval(msg_eval) => {
+                    // Deserialize eval
+                    let Ok(eval): Result<EcdhCoinTossEval<CG, _>, _> = msg_eval.borrow().try_into()
+                    else {
+                        warn!("Failed to deserialize CoinEvalMessage");
+                        continue;
+                    };
+
+                    // Store one eval per party, per round. We cannot verify it here
+                    // since the node may not be ready to check evaluations yet.
+                    let mut coin_evals = state.coin_evals.lock().await;
+                    coin_evals.insert_once(msg_eval.round, sender_id, eval);
+                    let count = coin_evals.get_count(&msg_eval.round);
+                    drop(coin_evals); // drop lock
+
+                    // Notify if we have t + 1 evals
+                    if count > config.t {
+                        state.notify_enough_coin_evals.notify_one(msg_eval.round);
+                    }
+                }
+            };
+        }
+    }
+}

--- a/crates/adkg/src/scheme.rs
+++ b/crates/adkg/src/scheme.rs
@@ -9,8 +9,7 @@ use crate::network::RetryStrategy;
 use crate::rbc::ReliableBroadcastConfig;
 use crate::rbc::r4::Rbc4RoundsConfig;
 use crate::vss::acss::AcssConfig;
-use crate::vss::acss::hbacss0::HbAcss0Config;
-use crate::vss::acss::hbacss0::PedersenSecret;
+use crate::vss::acss::hbacss0::{HbAcss0Config, Hbacss0Input};
 use ark_ec::{CurveGroup, PrimeGroup};
 use ark_std::UniformRand;
 use digest::core_api::BlockSizeUser;
@@ -51,7 +50,7 @@ where
             'static,
             Self::Curve,
             PartyId,
-            Input = Vec<PedersenSecret<<Self::Curve as PrimeGroup>::ScalarField>>,
+            Input = Hbacss0Input<<Self::Curve as PrimeGroup>::ScalarField>,
         >;
     type ABAConfig: AbaConfig<'static, PartyId>;
 

--- a/crates/adkg/src/vss/acss/hbacss0.rs
+++ b/crates/adkg/src/vss/acss/hbacss0.rs
@@ -11,9 +11,9 @@ use crate::helpers::PartyId;
 use crate::network::{RetryStrategy, broadcast_with_self};
 use crate::nizk::NIZKDleqProof;
 use crate::rbc::ReliableBroadcastConfig;
-use crate::vss::acss::hbacss0::types::{PedersenPartyShares, ShareRecoveryMessage};
-use crate::vss::pedersen;
+use crate::vss::acss::hbacss0::types::{PartyShares, ShareRecoveryMessage};
 use crate::vss::pedersen::PedersenPartyShare;
+use crate::vss::{feldman, pedersen};
 use crate::{
     pke::ec_hybrid_chacha20poly1305::{self, EphemeralMultiHybridCiphertext},
     rbc::{RbcPredicate, ReliableBroadcast},
@@ -123,19 +123,35 @@ pub struct PedersenSecret<F> {
     pub r: F,
 }
 
+/// The input of the Feldman + Pedersen-based ACSS.
+pub struct Hbacss0Input<F> {
+    pub feld: F,
+    pub peds: Vec<PedersenSecret<F>>,
+}
+
 /// The public polynomial output by the Pedersen-based ACSS.
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(bound(
     serialize = "CG: PointSerializeCompressed",
     deserialize = "CG: PointDeserializeCompressed"
 ))]
-pub struct PublicPoly<CG>(#[serde(with = "utils::serialize::point::base64::vec")] pub Vec<CG>);
+pub struct PedPublicPoly<CG>(#[serde(with = "utils::serialize::point::base64::vec")] pub Vec<CG>);
+
+/// The public polynomial output by the ACSS.
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(bound(
+    serialize = "CG: PointSerializeCompressed",
+    deserialize = "CG: PointDeserializeCompressed"
+))]
+pub struct FeldPublicPoly<CG>(#[serde(with = "utils::serialize::point::base64::vec")] pub Vec<CG>);
 
 /// The output of the Pedersen-based ACSS.
 #[derive(Clone)]
 pub struct Hbacss0Output<CG: CurveGroup> {
+    pub feld_share: CG::ScalarField,
+    pub feld_public_poly: FeldPublicPoly<CG>,
     pub shares: Vec<PedersenPartyShare<CG::ScalarField>>,
-    pub public_polys: Vec<PublicPoly<CG>>,
+    pub public_polys: Vec<PedPublicPoly<CG>>,
 }
 
 impl<'a, CG, H, RBCConfig> AcssConfig<'a, CG, PartyId> for HbAcss0Config<CG, H, RBCConfig>
@@ -146,7 +162,7 @@ where
     H: Default + DynDigest + FixedOutputReset + BlockSizeUser + Clone + 'static,
     RBCConfig: for<'lt_rbc> ReliableBroadcastConfig<'lt_rbc, PartyId> + 'a,
 {
-    type Input = Vec<PedersenSecret<CG::ScalarField>>;
+    type Input = Hbacss0Input<CG::ScalarField>;
     type Output = Hbacss0Output<CG>;
     type Error = Box<AcssError>;
 
@@ -218,12 +234,12 @@ where
     T: Transport<Identity = PartyId>,
 {
     type Error = Box<AcssError>;
-    type Input = Vec<PedersenSecret<CG::ScalarField>>;
+    type Input = Hbacss0Input<CG::ScalarField>;
     type Output = Hbacss0Output<CG>;
 
     async fn deal<RNG>(
         self,
-        ped_sks: Self::Input,
+        s: Self::Input,
         cancel: CancellationToken,
         output: oneshot::Sender<Self::Output>,
         rng: &mut RNG,
@@ -234,7 +250,7 @@ where
         let id = self.config.id;
         let res = select! {
             res = self.acss_dealer(
-                ped_sks,
+                s,
                 cancel.child_token(),
                 output,
                 rng
@@ -307,7 +323,7 @@ where
     /// Beginning of the ACSS protocol as the dealer.
     async fn acss_dealer<RNG>(
         mut self,
-        ped_sks: impl IntoIterator<Item = PedersenSecret<CG::ScalarField>>,
+        s: Hbacss0Input<CG::ScalarField>,
         rbc_cancel: CancellationToken,
         output: oneshot::Sender<Hbacss0Output<CG>>,
         rng: &mut RNG,
@@ -321,7 +337,10 @@ where
         // Pedersen's Polynomial Commitment of degree t where p(0) = s
         let g = self.config.g;
         let h = self.config.h;
-        let vss_shares: Vec<_> = ped_sks
+        let feld_vss_share = feldman::share(&s.feld, &g, self.config.n, self.config.t, rng);
+        let feld_public_poly = FeldPublicPoly(feld_vss_share.get_public_poly().to_vec());
+        let ped_vss_shares: Vec<_> = s
+            .peds
             .into_iter()
             .map(|ped_sk| {
                 pedersen::share(
@@ -335,25 +354,33 @@ where
                 )
             })
             .collect();
-        let public_polys: Vec<_> = vss_shares
+        let ped_public_polys: Vec<_> = ped_vss_shares
             .iter()
             .map(|vss_share| vss_share.get_public_poly().to_vec().into())
             .collect();
 
+        let get_party_shares = |i| {
+            let feld_share = *feld_vss_share
+                .get_party_secrets(i)
+                .expect("feldan output less than n shares");
+            let ped_shares: Vec<_> = ped_vss_shares
+                .iter()
+                .map(|vss_share| {
+                    vss_share
+                        .get_party_secrets(&i)
+                        .expect("feldman output less than n shares") // gen n shares, loop n times
+                })
+                .collect();
+            PartyShares {
+                feld_share,
+                ped_shares,
+            }
+        };
+
         // Encrypt and Disperse
         // Each share is encrypted towards the receiving party
         let shares = PartyId::iter_all(self.config.n)
-            .map(|i| -> Result<Vec<u8>, _> {
-                let shares: Vec<_> = vss_shares
-                    .iter()
-                    .map(|vss_share| {
-                        vss_share
-                            .get_party_secrets(&i)
-                            .expect("feldman output less than n shares") // gen n shares, loop n times
-                    })
-                    .collect();
-                bson::to_vec(&PedersenPartyShares { shares })
-            })
+            .map(|i| -> Result<Vec<u8>, _> { bson::to_vec(&get_party_shares(i)) })
             .collect::<Result<Vec<Vec<u8>>, _>>()
             .map_err(|e| AcssError::BsonSer(e, "dealer failed to serialize vss shares"))?; // unexpected error, abort ACSS
 
@@ -364,7 +391,8 @@ where
         // Disperse encrypted shares and public polynomial through the broadcast channel
         let broadcast = AcssBroadcastMessage {
             enc_shares,
-            public_polys: public_polys.clone(),
+            feld_public_poly: feld_public_poly.clone(),
+            ped_public_polys: ped_public_polys.clone(),
         };
         let m = bson::to_vec(&broadcast)
             .map_err(|e| AcssError::BsonSer(e, "dealer failed to serialize broadcast message"))?; // unexpected error, abort ACSS
@@ -384,14 +412,13 @@ where
 
         // Continue the execution of the acss protocol as a normal participant.
         let id = self.config.id;
+        let shares = get_party_shares(id);
         self.acss_continue(
-            vss_shares
-                .iter()
-                .map(|vss_share| vss_share.get_party_secrets(&id))
-                .collect(),
+            Some(shares),
             output,
             &broadcast.enc_shares,
-            public_polys,
+            feld_public_poly,
+            ped_public_polys,
             rng,
         )
         .await
@@ -446,13 +473,15 @@ where
         // Decrypt and validate share
         let enc_shares = &m.enc_shares;
         let shared_key = enc_shares.derive_shared_key(&self.config.sk);
-        let public_polys = m.public_polys;
+        let feld_public_poly = m.feld_public_poly;
+        let ped_public_polys = m.ped_public_polys;
 
         // If the share is valid, the nodes enters the reconstruction process
         // otherwise, the node enters the recovery process
-        let share = ped_eval_verify(
+        let shares = dual_eval_verify(
             enc_shares,
-            public_polys.iter(),
+            &feld_public_poly,
+            ped_public_polys.iter(),
             &self.config.g,
             &self.config.h,
             self.config.id,
@@ -460,17 +489,25 @@ where
             &self.config.pks[self.config.id],
         )
         .ok();
-        self.acss_continue(share, output, &m.enc_shares, public_polys, rng)
-            .await
+        self.acss_continue(
+            shares,
+            output,
+            &m.enc_shares,
+            feld_public_poly,
+            ped_public_polys,
+            rng,
+        )
+        .await
     }
 
     /// Execute the agreement / implication / share recovery part of the protocol.
     async fn acss_continue<RNG>(
         self,
-        shares: Option<Vec<PedersenPartyShare<CG::ScalarField>>>,
+        shares: Option<PartyShares<CG::ScalarField>>,
         output: oneshot::Sender<Hbacss0Output<CG>>,
         enc_shares: &EphemeralMultiHybridCiphertext<CG>,
-        public_polys: Vec<PublicPoly<CG>>,
+        feld_public_poly: FeldPublicPoly<CG>,
+        ped_public_polys: Vec<PedPublicPoly<CG>>,
         rng: &mut RNG,
     ) -> Result<(), Box<AcssError>>
     where
@@ -582,7 +619,12 @@ where
 
                 AcssMessage::Ready => {
                     hbacss0
-                        .ready_handler(sender, &mut state_machine, &public_polys)
+                        .ready_handler(
+                            sender,
+                            &mut state_machine,
+                            &feld_public_poly,
+                            &ped_public_polys,
+                        )
                         .await
                 }
 
@@ -591,7 +633,8 @@ where
                         .implicate_handler(
                             &ski,
                             enc_shares,
-                            &public_polys,
+                            &feld_public_poly,
+                            &ped_public_polys,
                             sender,
                             &mut state_machine,
                         )
@@ -603,7 +646,8 @@ where
                         .recovery_handler(
                             &shared_key,
                             enc_shares,
-                            &public_polys,
+                            &feld_public_poly,
+                            &ped_public_polys,
                             sender,
                             &mut state_machine,
                         )
@@ -622,13 +666,15 @@ where
 impl<CG: CurveGroup> From<Hbacss0Output<CG>> for ShareWithPoly<CG> {
     fn from(value: Hbacss0Output<CG>) -> Self {
         Self {
+            mvba_public_poly: value.feld_public_poly,
+            mvba_share: value.feld_share,
             public_polys: value.public_polys,
             shares: value.shares,
         }
     }
 }
 
-impl<CG> PublicPoly<CG> {
+impl<CG> PedPublicPoly<CG> {
     pub fn to_vec(self) -> Vec<CG> {
         self.0
     }
@@ -638,7 +684,7 @@ impl<CG> PublicPoly<CG> {
     }
 }
 
-impl<CG> From<Vec<CG>> for PublicPoly<CG> {
+impl<CG> From<Vec<CG>> for PedPublicPoly<CG> {
     fn from(v: Vec<CG>) -> Self {
         Self(v)
     }
@@ -671,10 +717,12 @@ where
         // Decrypt and validate share
         let enc_shares = &m.enc_shares;
         let shared_key = enc_shares.derive_shared_key(&self.sk);
-        let public_poly = &m.public_polys;
-        ped_eval_verify(
+        let feld_public_poly = &m.feld_public_poly;
+        let ped_public_poly = &m.ped_public_polys;
+        dual_eval_verify(
             enc_shares,
-            public_poly,
+            feld_public_poly,
+            ped_public_poly,
             &self.g,
             &self.h,
             self.i,
@@ -686,15 +734,16 @@ where
 }
 
 /// Verify that a hybrid encryption ciphertext can be decrypted and is a valid Feldman share for party i.
-fn ped_eval_verify<'a, CG>(
+fn dual_eval_verify<'a, CG>(
     ct: &EphemeralMultiHybridCiphertext<CG>,
-    public_polys: impl IntoIterator<Item = &'a PublicPoly<CG>, IntoIter: ExactSizeIterator>,
+    feld_poly: &FeldPublicPoly<CG>,
+    ped_public_polys: impl IntoIterator<Item = &'a PedPublicPoly<CG>, IntoIter: ExactSizeIterator>,
     g: &CG,
     h: &CG,
     i: PartyId,
     shared_key: &CG,
     recipient_pk: &CG,
-) -> Result<Vec<PedersenPartyShare<CG::ScalarField>>, ()>
+) -> Result<PartyShares<CG::ScalarField>, ()>
 where
     CG: CurveGroup + PointSerializeCompressed,
     CG::ScalarField: FqDeserialize,
@@ -704,36 +753,47 @@ where
     let pt = ct
         .decrypt_one_with_shared_key(i.as_index(), shared_key, recipient_pk)
         .map_err(|_| {
-            warn!("Failed to decrypt pedersen party shares");
+            warn!("Failed to decrypt party shares");
         })?;
 
-    let PedersenPartyShares::<CG::ScalarField> { shares } = bson::from_slice(&pt).map_err(|e| {
-        warn!(error = ?e, "Failed to deserialize pedersen party shares");
+    let party_shares: PartyShares<CG::ScalarField> = bson::from_slice(&pt).map_err(|e| {
+        warn!(error = ?e, "Failed to deserialize party shares");
     })?;
+    let PartyShares {
+        feld_share,
+        ped_shares,
+    } = &party_shares;
 
-    let public_polys = public_polys.into_iter();
-    if public_polys.len() != shares.len() {
+    let public_polys = ped_public_polys.into_iter();
+    if public_polys.len() != ped_shares.len() {
         warn!(
             expected_len = public_polys.len(),
-            len = shares.len(),
+            len = ped_shares.len(),
             "Attempting to verify pedersen shares with invalid length"
         );
         Err(())?
     }
 
     // Try to verify the shares, or return Err(())
-    if public_polys.zip(shares.iter()).all(|(public_poly, share)| {
-        pedersen::eval_verify(
-            &public_poly.to_owned().to_vec(),
-            i.into(),
-            &share.si,
-            &share.ri,
-            g,
-            h,
-        )
-        .is_ok()
-    }) {
-        Ok(shares)
+    if feldman::eval_verify(&feld_poly.0, i, &feld_share, g).is_err() {
+        return Err(());
+    }
+
+    if public_polys
+        .zip(ped_shares.iter())
+        .all(|(public_poly, share)| {
+            pedersen::eval_verify(
+                &public_poly.to_owned().to_vec(),
+                i.into(),
+                &share.si,
+                &share.ri,
+                g,
+                h,
+            )
+            .is_ok()
+        })
+    {
+        Ok(party_shares)
     } else {
         Err(())
     }
@@ -777,7 +837,9 @@ mod tests {
     use crate::helpers::PartyId;
     use crate::rbc::r4::Rbc4RoundsConfig;
     use crate::vss::acss::AcssConfig;
-    use crate::vss::acss::hbacss0::{APPNAME, HbAcss0Config, NIZK_DLEQ_SUFFIX, PedersenSecret};
+    use crate::vss::acss::hbacss0::{
+        APPNAME, HbAcss0Config, Hbacss0Input, NIZK_DLEQ_SUFFIX, PedersenSecret,
+    };
     use crate::{
         helpers::{lagrange_interpolate_at, u64_from_usize},
         network::RetryStrategy,
@@ -785,6 +847,7 @@ mod tests {
     };
     use ark_bn254::Bn254;
     use ark_ec::{PrimeGroup, pairing::Pairing};
+    use ark_ff::Zero;
     use ark_std::UniformRand;
     use dcipher_network::topic::dispatcher::TopicDispatcher;
     use dcipher_network::transports::in_memory::MemoryNetwork;
@@ -811,6 +874,7 @@ mod tests {
         let g = G::generator();
         let h = ark_bn254::G1Projective::hash_to_curve(b"PEDERSEN_H", b"TEST_DST_PEDERSEN_H");
 
+        let feld_s = ScalarField::rand(&mut rand::thread_rng());
         let s = ScalarField::rand(&mut rand::thread_rng());
         let r = ScalarField::rand(&mut rand::thread_rng());
         let mut sks: VecDeque<ScalarField> = (1..=n)
@@ -858,7 +922,10 @@ mod tests {
                         .new_instance_with_prefix("hbacss0".to_owned(), Arc::new(transport))
                         .expect("failed to create acss instance");
                     acss.deal(
-                        vec![PedersenSecret { s, r }],
+                        Hbacss0Input {
+                            feld: feld_s,
+                            peds: vec![PedersenSecret { s, r }],
+                        },
                         cancellation_token,
                         sender,
                         &mut OsRng,
@@ -914,18 +981,28 @@ mod tests {
             });
         }
 
-        let mut shares = vec![];
+        let mut feld_shares = vec![];
+        let mut ped_shares = vec![];
         while let Some(res) = tasks.join_next().await {
             assert!(res.is_ok());
             let (i, out) = res.unwrap();
 
-            shares.push((i, out.shares[0].si));
+            ped_shares.push((i, out.shares[0].si));
+            feld_shares.push((i, out.feld_share));
         }
 
-        let s = lagrange_interpolate_at::<G>(&shares[0..=t], 0);
-        let s2 = lagrange_interpolate_at::<G>(&shares[t..=2 * t], 0);
+        let ped_s = lagrange_interpolate_at::<G>(&ped_shares[0..=t], 0);
+        let ped_s2 = lagrange_interpolate_at::<G>(&ped_shares[t..=2 * t], 0);
+        let feld_s = lagrange_interpolate_at::<G>(&feld_shares[0..=t], 0);
+        let feld_s2 = lagrange_interpolate_at::<G>(&feld_shares[t..=2 * t], 0);
 
-        assert_eq!(s, s2)
+        assert_eq!(ped_s, ped_s2);
+        assert!(!ped_s.is_zero());
+
+        assert_eq!(feld_s, feld_s2);
+        assert!(!feld_s.is_zero());
+
+        assert_ne!(ped_s, feld_s);
     }
 
     #[test]

--- a/crates/adkg/src/vss/acss/hbacss0.rs
+++ b/crates/adkg/src/vss/acss/hbacss0.rs
@@ -734,6 +734,7 @@ where
 }
 
 /// Verify that a hybrid encryption ciphertext can be decrypted and is a valid Feldman share for party i.
+#[allow(clippy::too_many_arguments)]
 fn dual_eval_verify<'a, CG>(
     ct: &EphemeralMultiHybridCiphertext<CG>,
     feld_poly: &FeldPublicPoly<CG>,
@@ -775,7 +776,7 @@ where
     }
 
     // Try to verify the shares, or return Err(())
-    if feldman::eval_verify(&feld_poly.0, i, &feld_share, g).is_err() {
+    if feldman::eval_verify(&feld_poly.0, i, feld_share, g).is_err() {
         return Err(());
     }
 

--- a/crates/adkg/src/vss/acss/hbacss0/handlers.rs
+++ b/crates/adkg/src/vss/acss/hbacss0/handlers.rs
@@ -1,18 +1,18 @@
 //! Handlers for the various messages sent during the ACSS protocol.
 
 use super::{
-    AcssMessage, AcssStatus, HbAcss0Instance, Hbacss0Output, ImplicateMessage, PublicPoly,
-    StateMachine,
+    AcssMessage, AcssStatus, FeldPublicPoly, HbAcss0Instance, Hbacss0Output, ImplicateMessage,
+    PedPublicPoly, StateMachine,
 };
 use crate::helpers::PartyId;
 use crate::network::broadcast_with_self;
 use crate::rbc::ReliableBroadcastConfig;
-use crate::vss::acss::hbacss0::types::ShareRecoveryMessage;
+use crate::vss::acss::hbacss0::types::{PartyShares, ShareRecoveryMessage};
 use crate::vss::pedersen::PedersenPartyShare;
 use crate::{
     helpers::lagrange_interpolate_at, nizk::NIZKDleqProof,
     pke::ec_hybrid_chacha20poly1305::EphemeralMultiHybridCiphertext,
-    vss::acss::hbacss0::ped_eval_verify,
+    vss::acss::hbacss0::dual_eval_verify,
 };
 use ark_ec::CurveGroup;
 use dcipher_network::TransportSender;
@@ -81,7 +81,8 @@ where
         &self,
         sender: PartyId,
         state_machine: &mut StateMachine<CG>,
-        public_polys: &[PublicPoly<CG>],
+        feld_public_poly: &FeldPublicPoly<CG>,
+        ped_public_polys: &[PedPublicPoly<CG>],
     ) {
         // Skip messages if not waiting for Ok nor Readys nor in ShareRecovery
         match state_machine.status {
@@ -147,8 +148,10 @@ where
 
                         if output
                             .send(Hbacss0Output {
-                                shares: shares.to_owned(),
-                                public_polys: public_polys.to_vec(),
+                                feld_share: shares.feld_share.clone(),
+                                shares: shares.ped_shares.clone(),
+                                feld_public_poly: feld_public_poly.to_owned(),
+                                public_polys: ped_public_polys.to_vec(),
                             })
                             .is_err()
                         {
@@ -184,7 +187,8 @@ where
         &self,
         msg: &ImplicateMessage,
         enc_shares: &EphemeralMultiHybridCiphertext<CG>,
-        public_polys: &[PublicPoly<CG>],
+        feld_public_poly: &FeldPublicPoly<CG>,
+        ped_public_polys: &[PedPublicPoly<CG>],
         sender: PartyId,
         state_machine: &mut StateMachine<CG>,
     ) where
@@ -259,9 +263,10 @@ where
         }
 
         // We know that the sender gave us a valid shared key, try to decrypt the original ciphertext sent by the dealer.
-        if ped_eval_verify(
+        if dual_eval_verify(
             enc_shares,
-            public_polys,
+            feld_public_poly,
+            ped_public_polys,
             &self.config.g,
             &self.config.h,
             sender,
@@ -316,7 +321,8 @@ where
         &self,
         shared_key: &[u8],
         enc_shares: &EphemeralMultiHybridCiphertext<CG>,
-        public_polys: &[PublicPoly<CG>],
+        feld_public_poly: &FeldPublicPoly<CG>,
+        ped_public_polys: &[PedPublicPoly<CG>],
         sender: PartyId,
         state_machine: &mut StateMachine<CG>,
     ) where
@@ -344,9 +350,10 @@ where
 
         // We don't verify the source / validity of the shared key.
         // We only need it such that decryption results in a valid dealer's share.
-        let Ok(shares) = ped_eval_verify(
+        let Ok(shares) = dual_eval_verify(
             enc_shares,
-            public_polys,
+            feld_public_poly,
+            ped_public_polys,
             &self.config.g,
             &self.config.h,
             sender,
@@ -368,10 +375,13 @@ where
         #[allow(clippy::int_plus_one)]
         if state_machine.shares_recovery.len() >= self.config.t + 1 {
             // Enough valid shares, interpolate the polynomial
+
             let n = state_machine.shares_recovery.len();
             let mut points_peds: Vec<(Vec<_>, Vec<_>)> = vec![];
+            let mut points_feld = vec![];
             for (&k, shares) in state_machine.shares_recovery.iter() {
-                for (share_idx, share) in shares.iter().enumerate() {
+                points_feld.push((k.into(), shares.feld_share));
+                for (share_idx, share) in shares.ped_shares.iter().enumerate() {
                     if points_peds.len() <= share_idx {
                         points_peds.push((Vec::with_capacity(n), Vec::with_capacity(n)));
                     }
@@ -381,6 +391,7 @@ where
                 }
             }
 
+            let feld_share = lagrange_interpolate_at::<CG>(&points_feld, self.config.id.into());
             let Some(new_shares) = points_peds
                 .into_iter()
                 .map(|(points_si, points_ri)| {
@@ -426,7 +437,10 @@ where
             }
 
             // Update state machine
-            state_machine.status = AcssStatus::WaitingForReadys(new_shares);
+            state_machine.status = AcssStatus::WaitingForReadys(PartyShares {
+                feld_share,
+                ped_shares: new_shares,
+            });
         }
     }
 }

--- a/crates/adkg/src/vss/acss/hbacss0/handlers.rs
+++ b/crates/adkg/src/vss/acss/hbacss0/handlers.rs
@@ -148,7 +148,7 @@ where
 
                         if output
                             .send(Hbacss0Output {
-                                feld_share: shares.feld_share.clone(),
+                                feld_share: shares.feld_share,
                                 shares: shares.ped_shares.clone(),
                                 feld_public_poly: feld_public_poly.to_owned(),
                                 public_polys: ped_public_polys.to_vec(),


### PR DESCRIPTION
Two issues are fixed in that PR. 

The first is to wait for RBC instances to completes once all ABAs have been completed. Not a bug, but otherwise the ABAs may run for longer, which results in unnecessary communications.

The second issue, was more problematic, but with low probability of occurring. Essentially, before executing the final RBC, we were waiting as follows:
```
loop {
  if rbc_input \subset current_acss_completed
    break;
  else
    await register_notification();
}
```

With the way the notification system works, a permit is only stored if a thread is already waiting, otherwise, no permit was issued. This means that if the notification occurred right after the condition, and before we actually await on the notification, it would be missed.

I fixed it by registering for the notification prior to checking the condition:
```
loop {
  notification = register_notification();
  if rbc_input \subset current_acss_completed
    break;
  else
    await notification;
}
```